### PR TITLE
Apply yellow neon theme and remove toggle

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -67,19 +67,6 @@
 
         // Initialize particles when page loads
         document.addEventListener('DOMContentLoaded', function() {
-            const themeStylesheet = document.getElementById('themeStylesheet');
-            const themeToggle = document.getElementById('themeToggle');
-
-            const savedTheme = localStorage.getItem('theme') || 'mono';
-            themeStylesheet.setAttribute('href', savedTheme === 'neon' ? 'assets/neon.css' : 'assets/style.css');
-
-            themeToggle.addEventListener('click', () => {
-                const current = themeStylesheet.getAttribute('href').includes('neon') ? 'neon' : 'mono';
-                const next = current === 'neon' ? 'mono' : 'neon';
-                themeStylesheet.setAttribute('href', next === 'neon' ? 'assets/neon.css' : 'assets/style.css');
-                localStorage.setItem('theme', next);
-            });
-
             const { container, particles } = createParticles();
             createConnections(container, particles);
             loadFromStorage();

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,11 +1,8 @@
         .dark-bg {
-            background: radial-gradient(ellipse at center, #111111 0%, #000000 100%);
+            background: radial-gradient(ellipse at center, #332200 0%, #000000 100%);
             min-height: 100vh;
             position: relative;
             overflow-x: hidden;
-
-            filter: grayscale(100%);
-
         }
         
         .dark-bg::before {
@@ -16,9 +13,9 @@
             right: 0;
             bottom: 0;
             background:
-                radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.03) 0%, transparent 50%),
-                radial-gradient(circle at 80% 70%, rgba(255, 255, 255, 0.02) 0%, transparent 50%),
-                radial-gradient(circle at 40% 80%, rgba(255, 255, 255, 0.02) 0%, transparent 50%);
+                radial-gradient(circle at 20% 30%, rgba(255, 255, 170, 0.06) 0%, transparent 50%),
+                radial-gradient(circle at 80% 70%, rgba(255, 255, 170, 0.04) 0%, transparent 50%),
+                radial-gradient(circle at 40% 80%, rgba(255, 255, 170, 0.04) 0%, transparent 50%);
             pointer-events: none;
             z-index: 0;
         }
@@ -46,10 +43,10 @@
             z-index: 1;
             width: 2px;
             height: 2px;
-            background: rgba(255, 255, 255, 0.6);
+            background: rgba(255, 223, 0, 0.6);
             border-radius: 50%;
             animation: float 6s infinite linear;
-            box-shadow: 0 0 6px rgba(255, 255, 255, 0.8);
+            box-shadow: 0 0 6px rgba(255, 223, 0, 0.8);
         }
 
         @keyframes float {
@@ -71,20 +68,20 @@
 
         .particle:nth-child(2n) {
             animation-duration: 8s;
-            background: rgba(255, 255, 255, 0.4);
-            box-shadow: 0 0 4px rgba(255, 255, 255, 0.6);
+            background: rgba(255, 223, 0, 0.4);
+            box-shadow: 0 0 4px rgba(255, 223, 0, 0.6);
         }
 
         .particle:nth-child(3n) {
             animation-duration: 10s;
-            background: rgba(255, 255, 255, 0.3);
-            box-shadow: 0 0 3px rgba(255, 255, 255, 0.5);
+            background: rgba(255, 223, 0, 0.3);
+            box-shadow: 0 0 3px rgba(255, 223, 0, 0.5);
         }
 
         .particle-lines line {
-            stroke: rgba(255, 255, 255, 0.2);
+            stroke: rgba(255, 223, 0, 0.2);
             stroke-width: 1;
-            filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.4));
+            filter: drop-shadow(0 0 4px rgba(255, 223, 0, 0.4));
         }
         
         .matte-card { 
@@ -415,7 +412,7 @@
         
         .counter-badge {
             background: rgba(99, 102, 241, 0.7);
-            color: white;
+            color: #ffe066;
             font-weight: 600;
             border: 1px solid rgba(99, 102, 241, 0.3);
             backdrop-filter: blur(10px);
@@ -429,27 +426,45 @@
         .section-header:hover {
             background: rgba(17, 24, 39, 0.9);
         }
-        
+
+        body,
+        .text-gray-200,
+        .text-gray-300,
+        .text-gray-400,
+        .text-gray-500,
+        .text-gray-600,
+        .text-gray-700,
+        .text-gray-800,
+        .text-gray-900,
+        .text-white,
+        .text-indigo-300,
+        .text-indigo-400,
+        .text-red-300 {
+            color: #ffe066 !important;
+            text-shadow: 0 0 5px rgba(255, 223, 0, 0.8), 0 0 10px rgba(255, 223, 0, 0.5);
+        }
+
         .glow-text {
+            color: #ffe066;
             text-shadow:
-                0 0 10px rgba(255, 255, 255, 0.8),
-                0 0 20px rgba(255, 255, 255, 0.6),
-                0 0 30px rgba(255, 255, 255, 0.4);
+                0 0 10px rgba(255, 223, 0, 0.8),
+                0 0 20px rgba(255, 223, 0, 0.6),
+                0 0 30px rgba(255, 223, 0, 0.4);
             animation: textGlow 2s ease-in-out infinite alternate;
         }
 
         @keyframes textGlow {
             0% {
-                text-shadow: 
-                    0 0 10px rgba(255, 255, 255, 0.8),
-                    0 0 20px rgba(255, 255, 255, 0.6),
-                    0 0 30px rgba(255, 255, 255, 0.4);
+                text-shadow:
+                    0 0 10px rgba(255, 223, 0, 0.8),
+                    0 0 20px rgba(255, 223, 0, 0.6),
+                    0 0 30px rgba(255, 223, 0, 0.4);
             }
             100% {
-                text-shadow: 
-                    0 0 15px rgba(255, 255, 255, 1),
-                    0 0 25px rgba(255, 255, 255, 0.8),
-                    0 0 35px rgba(255, 255, 255, 0.6);
+                text-shadow:
+                    0 0 15px rgba(255, 223, 0, 1),
+                    0 0 25px rgba(255, 223, 0, 0.8),
+                    0 0 35px rgba(255, 223, 0, 0.6);
             }
         }
         
@@ -459,9 +474,9 @@
         
         @keyframes pulse-glow {
             from {
-                box-shadow: 0 0 20px rgba(255, 255, 255, 0.2);
+                box-shadow: 0 0 20px rgba(255, 223, 0, 0.2);
             }
             to {
-                box-shadow: 0 0 30px rgba(255, 255, 255, 0.4);
+                box-shadow: 0 0 30px rgba(255, 223, 0, 0.4);
             }
         }

--- a/index.html
+++ b/index.html
@@ -14,9 +14,6 @@
     </div>
     
     <div class="max-w-7xl mx-auto relative z-10">
-        <div class="flex justify-end mb-4">
-            <button id="themeToggle" class="btn-ghost px-4 py-2 rounded-xl font-semibold text-sm">🎨 Toggle Theme</button>
-        </div>
         <!-- Header -->
         <div class="text-center mb-8">
             <div class="glass-header rounded-2xl p-8 mx-auto max-w-3xl pulse-glow">


### PR DESCRIPTION
## Summary
- remove theme toggle button and simplify initialization
- refresh style with yellow neon background and particles
- switch site typography to glowing yellow for better contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a04e022ad48332b0d94f731cfe0b9c