### PR TITLE
style: darken background gradient

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -8,7 +8,7 @@
         .dark-bg {
             background:
                 repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.08) 0, rgba(255, 255, 255, 0.08) 2px, transparent 2px, transparent 8px),
-                radial-gradient(ellipse at center, #fffde7 0%, #ffe082 100%);
+                radial-gradient(ellipse at center, #0d1b2a 0%, #000814 100%);
             min-height: 100vh;
             position: relative;
             overflow-x: hidden;
@@ -22,9 +22,9 @@
             right: 0;
             bottom: 0;
             background:
-                radial-gradient(circle at 20% 30%, rgba(255, 255, 204, 0.3) 0%, transparent 60%),
-                radial-gradient(circle at 80% 70%, rgba(255, 255, 204, 0.25) 0%, transparent 60%),
-                radial-gradient(circle at 40% 80%, rgba(255, 255, 204, 0.25) 0%, transparent 60%);
+                radial-gradient(circle at 20% 30%, rgba(13, 27, 42, 0.3) 0%, transparent 60%),
+                radial-gradient(circle at 80% 70%, rgba(13, 27, 42, 0.25) 0%, transparent 60%),
+                radial-gradient(circle at 40% 80%, rgba(13, 27, 42, 0.25) 0%, transparent 60%);
             pointer-events: none;
             z-index: 0;
         }


### PR DESCRIPTION
## Summary
- replace yellow gradient with dark galaxy blue tones in `.dark-bg`
- update pseudo-element glow colors to matching blues

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/claim/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a0c4996d2c8332bce8d4b7cde56ba4